### PR TITLE
Include more whitespace characters in `is_whitespace`

### DIFF
--- a/src/nibble/predicates.gleam
+++ b/src/nibble/predicates.gleam
@@ -32,7 +32,7 @@ pub fn is_digit(grapheme: String) -> Bool {
 
 pub fn is_whitespace(grapheme: String) -> Bool {
   case grapheme {
-    " " | "\t" | "\r" | "\n" -> True
+    " " | "\t" | "\r" | "\n" | "\f" | "\r\n" -> True
     _ -> False
   }
 }


### PR DESCRIPTION
Form Feed: `\f`
Windows newline: `\r\n`