### PR TITLE
Fix deprecations for new gleam_stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,6 +12,7 @@ gleam = ">= 0.34.0"
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 1.0.0"
 glearray = ">= 1.0.0 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
   { name = "glearray", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glearray", source = "hex", outer_checksum = "B99767A9BC63EF9CC8809F66C7276042E5EFEACAA5B25188B552D3691B91AC6D" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 1.0.0" }
 glearray = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/test/docs/lexer_modes/indentation_test.gleam
+++ b/test/docs/lexer_modes/indentation_test.gleam
@@ -3,7 +3,7 @@
 import gleam/int
 import gleam/io
 import gleam/order.{Eq, Gt, Lt}
-import gleam/regex
+import gleam/regexp
 import gleam/set
 import gleam/string
 import gleeunit/should
@@ -89,11 +89,11 @@ fn should(
 }
 
 fn lexer(_) -> List(Matcher(TokenT, Int)) {
-  let assert Ok(is_indent) = regex.from_string("^\\n[ \\t]*")
+  let assert Ok(is_indent) = regexp.from_string("^\\n[ \\t]*")
   let indentation = {
     use current_indent, lexeme, lookahead <- lexer.custom
 
-    case regex.check(is_indent, lexeme), lookahead {
+    case regexp.check(is_indent, lexeme), lookahead {
       False, _ -> NoMatch
       True, " " | True, "\t" -> Skip
       True, "\n" -> Drop(current_indent)


### PR DESCRIPTION
I came across these deprecations when upgrading to the most recent version of the `gleam_stdlib` in my project. Thought I might be able to help. I have no idea of the usual etiquette for version upgrades in packages so let me know if anything is wrong or if this isn't helpful!

Things that were changed:
- Replace gleam/regex with the new gleam/regexp package
- Replace string.drop_left with string.drop_start
- Replace string.drop_right with string.drop_end