### PR TITLE
Fix Gleam deprecations

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ version = "1.1.3"
 #
 licences = ["MIT"]
 description = "A string parsing library combining a traditional lexer with parser combinators.."
-repository = { type = "github", user = "hayleigh-dot-dev", repo = "gleam-nibble" }
+repository = { type = "github", user = "hayleigh-dot-dev", repo = "nibble" }
 gleam = ">= 0.34.0"
 
 internal_modules = ["nibble/vendor/*"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,9 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
-  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
+  { name = "gleam_stdlib", version = "0.62.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DC8872BC0B8550F6E22F0F698CFE7F1E4BDA7312FDEB40D6C3F44C5B706C8310" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
 ]
 
 [requirements]

--- a/src/nibble.gleam
+++ b/src/nibble.gleam
@@ -765,5 +765,5 @@ pub fn inspect(
   io.println(message <> ": ")
 
   runwrap(state, parser)
-  |> io.debug
+  |> echo
 }

--- a/src/nibble/lexer.gleam
+++ b/src/nibble/lexer.gleam
@@ -507,7 +507,7 @@ pub fn try_identifier(
   reserved: Set(String),
   to_value: fn(String) -> a,
 ) -> Result(Matcher(a, mode), regexp.CompileError) {
-  use ident <- result.then(regexp.from_string("^" <> start <> inner <> "*$"))
+  use ident <- result.try(regexp.from_string("^" <> start <> inner <> "*$"))
   use inner <- result.map(regexp.from_string(inner))
 
   use mode, lexeme, lookahead <- Matcher


### PR DESCRIPTION
I wanted to use this library with Gleam 1.11.1 and it complained about `io.debug`