### PR TITLE
Replace `io.debug` with `echo`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           otp-version: "27.0"
           rebar3-version: "3"
-          gleam-version: "1.5.1"
+          gleam-version: "1.11.1"
 
       - run: |
           version="v$(cat gleam.toml | grep -m 1 "version" | sed -r "s/version *= *\"([[:digit:].]+)\"/\1/")"

--- a/src/nibble.gleam
+++ b/src/nibble.gleam
@@ -765,5 +765,5 @@ pub fn inspect(
   io.println(message <> ": ")
 
   runwrap(state, parser)
-  |> io.debug
+  |> echo
 }


### PR DESCRIPTION
This PR replaces the use of `io.debug` with the `echo` keyword.

`io.debug` was deprecated in v0.59.0 of `gleam_stdlib` and removed entirely in v0.61.0.

This does involve depending on Gleam v1.9 or higher.