### PR TITLE
Remove `io.debug` usage

### DIFF
--- a/docs/00-introduction.md
+++ b/docs/00-introduction.md
@@ -55,7 +55,7 @@ pub fn main() {
   case tokens |> nibble.run(parser()) {
     Ok(value) -> io.println(value)
     Error(err) -> {
-      let _ = io.debug(err)
+      let _ = io.println_error(string.inspect(err))
       Nil
     }
   }

--- a/src/nibble.gleam
+++ b/src/nibble.gleam
@@ -764,6 +764,8 @@ pub fn inspect(
   use state <- Parser
   io.println(message <> ": ")
 
-  runwrap(state, parser)
-  |> io.debug
+  let step = runwrap(state, parser)
+  io.println_error(string.inspect(step))
+
+  step
 }


### PR DESCRIPTION
This PR removes the usage of `io.debug` in favor of using `string.inspect` and `io.println_error`.

`io.debug` was deprecated in v0.59.0 of `gleam_stdlib` and removed entirely in v0.61.0.