### PR TITLE
Allow gleam_stdlib up to v2, update dependencies

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ repository = { type = "github", user = "hayleigh-dot-dev", repo = "gleam-nibble"
 
 
 [dependencies]
-gleam_stdlib = ">= 0.62.0 and < 1.0.0"
+gleam_stdlib = ">= 0.62.0 and < 2.0.0"
 gleam_regexp = ">= 1.0.0 and < 2.0.0"
 iv = ">= 1.3.2 and < 2.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,14 +3,14 @@
 
 packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
-  { name = "gleam_stdlib", version = "0.62.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DC8872BC0B8550F6E22F0F698CFE7F1E4BDA7312FDEB40D6C3F44C5B706C8310" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
-  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
-  { name = "iv", version = "1.3.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "iv", source = "hex", outer_checksum = "1FE22E047705BE69EA366E3A2E73C2E1310CBCB27DDE767DE17AE3FA86499947" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "iv", version = "1.4.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "iv", source = "hex", outer_checksum = "C9B1940787A3318D0B51701EE5AD416010215B5FDC1E582D74106CE9F4381C85" },
 ]
 
 [requirements]
 gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.62.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.62.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 iv = { version = ">= 1.3.2 and < 2.0.0" }


### PR DESCRIPTION
The minimum stdlib version does not need updating, as this library does not use any stdlib functions that changed between the minimum v0.62 and the latest v1.

This means this is not a breaking change and can be released as a point-release.